### PR TITLE
Upgrade Bevy to 0.18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This is a Rust library crate for integrating system tray icons with Bevy. Core library code lives in `src/`, with submodules under `src/resource/` and `src/plugin/`. Example apps and demo media are in `examples/` (see `examples/window_visible.rs` and `examples/window_visible.gif`). Static assets used for demos live in `assets/`. Build artifacts land in `target/` and should not be committed.
+
+## Build, Test, and Development Commands
+- `cargo build`: Compile the library.
+- `cargo test`: Run unit tests (if present).
+- `cargo run --example window_visible`: Launch the demo example.
+- `cargo fmt`: Format Rust sources using rustfmt.
+- `cargo clippy`: Run lint checks; prefer fixing warnings before submitting.
+
+## Coding Style & Naming Conventions
+Use standard Rust 2021 style. Prefer 4-space indentation, `snake_case` for functions/modules, and `CamelCase` for types. Keep modules focused and small; public APIs should live in `src/lib.rs` and be re-exported as needed. Avoid adding unnecessary dependencies and keep `bevy` features minimal (see `Cargo.toml`).
+
+## Testing Guidelines
+There is no dedicated `tests/` directory currently. If you add tests, place unit tests in the same module under `#[cfg(test)]` and name tests descriptively (e.g., `creates_menu_item`). For integration tests, add a `tests/` directory and use filenames like `menu_item.rs`. Run `cargo test` before opening a PR.
+
+## Commit & Pull Request Guidelines
+Recent history shows short, action-focused commit messages like `add: change logs` and `update: README.md`, sometimes with PR references (e.g., `(#2)`). Follow that pattern: start with a clear verb and keep it concise. PRs should include:
+- A brief description of the change and its motivation.
+- Any relevant example commands or screenshots/GIFs (especially for UI/demo updates).
+- Notes about compatibility with Bevy versions if impacted.
+
+## Notes
+This crate targets Bevy `0.18` and uses the `tray-icon` crate. If you change compatibility, update `README.md` and `CHANGELOG.md` accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Breaking Changes
 
+ - Upgrade Bevy to v0.18
+ - Renamed `MenuEvent` to `MenuMessage`
+
 ## v0.2.0
 
 [release notes](https://github.com/not-elm/bevy_tray_icon/releases/tag/v0.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.3.0
+
+### Breaking Changes
+
 ## v0.2.0
 
 [release notes](https://github.com/not-elm/bevy_tray_icon/releases/tag/v0.2.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tray_icon"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["notelm"]
 categories = ["game-development"]
@@ -12,7 +12,7 @@ repository = "https://github.com/not-elm/bevy_tray_icon"
 exclude = ["assets/"]
 
 [dependencies]
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
     "bevy_asset",
     "bevy_render"
 ] }
@@ -20,7 +20,7 @@ tray-icon = "0.21.0"
 thiserror = "2"
 
 [dev-dependencies]
-bevy = "0.16"
+bevy = "0.18"
 
 [lints.clippy]
 type_complexity = "allow"

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Please see [here](https://github.com/not-elm/bevy_tray_icon/blob/main/CHANGELOG.
 
 | bevy_tray_icon | bevy   |
 |----------------|--------|
-| 0.2.0~         | 0.16.0 |
-| 0.1.0~         | 0.13.2 |
+| 0.3.0 ~        | 0.18.0 |
+| 0.2.0 ~        | 0.16.0 |
+| 0.1.0 ~        | 0.13.2 |
 
 ## License
 

--- a/examples/window_visible.rs
+++ b/examples/window_visible.rs
@@ -6,7 +6,7 @@
 
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
-use bevy_tray_icon::plugin::menu_event::MenuEvent;
+use bevy_tray_icon::plugin::menu_event::MenuMessage;
 use bevy_tray_icon::plugin::TrayIconPlugin;
 use bevy_tray_icon::resource::{Menu, MenuItem, TrayIcon};
 
@@ -26,7 +26,7 @@ fn main() {
         .add_systems(
             Update,
             (
-                menu_event,
+                menu_messages,
                 change_menu_enable.run_if(resource_exists::<TrayIcon>),
             ),
         )
@@ -45,7 +45,7 @@ fn create_tray(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
 }
 
-fn menu_event(mut er: EventReader<MenuEvent>, mut window: Query<&mut Window, With<PrimaryWindow>>) {
+fn menu_messages(mut er: MessageReader<MenuMessage>, mut window: Query<&mut Window, With<PrimaryWindow>>) {
     for e in er.read() {
         match e.id.0.as_str() {
             "visible" => {

--- a/examples/window_visible.rs
+++ b/examples/window_visible.rs
@@ -45,7 +45,10 @@ fn create_tray(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
 }
 
-fn menu_messages(mut er: MessageReader<MenuMessage>, mut window: Query<&mut Window, With<PrimaryWindow>>) {
+fn menu_messages(
+    mut er: MessageReader<MenuMessage>,
+    mut window: Query<&mut Window, With<PrimaryWindow>>,
+) {
     for e in er.read() {
         match e.id.0.as_str() {
             "visible" => {

--- a/src/plugin/menu_event.rs
+++ b/src/plugin/menu_event.rs
@@ -14,7 +14,8 @@ pub(crate) struct MenuEventPlugin;
 
 impl Plugin for MenuEventPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<MenuMessage>().add_systems(Update, menu_event);
+        app.add_message::<MenuMessage>()
+            .add_systems(Update, menu_event);
     }
 }
 

--- a/src/plugin/menu_event.rs
+++ b/src/plugin/menu_event.rs
@@ -1,12 +1,11 @@
 //! Convert system tray events to bevy events.
 
-use bevy::app::{App, Plugin, Update};
-use bevy::prelude::{Event, EventWriter};
+use bevy::prelude::*;
 use tray_icon::menu::MenuId;
 
 /// The event fired when a menu is clicked.
-#[derive(Event, Debug, Eq, PartialEq)]
-pub struct MenuEvent {
+#[derive(Message, Debug, Eq, PartialEq)]
+pub struct MenuMessage {
     /// The id of the clicked menu.
     pub id: MenuId,
 }
@@ -15,12 +14,12 @@ pub(crate) struct MenuEventPlugin;
 
 impl Plugin for MenuEventPlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<MenuEvent>().add_systems(Update, menu_event);
+        app.add_message::<MenuMessage>().add_systems(Update, menu_event);
     }
 }
 
-fn menu_event(mut ew: EventWriter<MenuEvent>) {
+fn menu_event(mut ew: MessageWriter<MenuMessage>) {
     while let Ok(event) = tray_icon::menu::MenuEvent::receiver().try_recv() {
-        ew.write(MenuEvent { id: event.id });
+        ew.write(MenuMessage { id: event.id });
     }
 }


### PR DESCRIPTION
## Summary
- upgrade Bevy dependency to v0.18
- update README and CHANGELOG for v0.3.0
- document MenuEvent -> MenuMessage rename

## Testing
- not run (doc/config changes only)